### PR TITLE
Atualização dos nomes e labels dos templates de issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/adicionar_evento .yml
+++ b/.github/ISSUE_TEMPLATE/adicionar_evento .yml
@@ -1,0 +1,182 @@
+name: "Vamos adicionar um novo evento?😁"
+description: Utilize essa opção para adicionar um novo evento!
+title: "(Atenção: O Título da Issue é gerado automaticamente. Sendo assim, não precisa definir um título manualmente aqui.)"
+labels: ["adicionar"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Vamos criar um novo evento?
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Informações Gerais do Evento
+
+  - type: input
+    id: event_name
+    attributes:
+      label: Nome do Evento
+      description: Qual o nome do evento?
+      placeholder: "ex: TDC 2025"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: event_format
+    attributes:
+      label: Formato do Evento
+      description: O evento será remoto, híbrido ou presencial?
+      multiple: false
+      options:
+        - Remoto
+        - Híbrido
+        - Presencial
+    validations:
+      required: true
+
+  - type: input
+    id: event_remote_url
+    attributes:
+      label: URL do Evento (caso remoto ou híbrido)
+      description: Informe a URL do evento se for remoto ou híbrido.
+      placeholder: "ex: https://evento-online.com/"
+    validations:
+      required: false
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Quando o evento vai acontecer?
+
+  - type: dropdown
+    id: event_year
+    attributes:
+      label: "Ano do Evento"
+      description: "Qual o ano que irá acontecer o evento?"
+      multiple: false
+      default: 0
+      options:
+        - "2025"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: event_month
+    attributes:
+      label: "Mês do Evento"
+      description: Em qual mês irá acontecer o evento?
+      multiple: false
+      default: 0
+      options:
+        - A anunciar
+        - Janeiro
+        - Fevereiro
+        - Março
+        - Abril
+        - Maio
+        - Junho
+        - Julho
+        - Agosto
+        - Setembro
+        - Outubro
+        - Novembro
+        - Dezembro
+    validations:
+      required: true
+
+  - type: dropdown
+    id: event_day
+    attributes:
+      label: "Dia do Evento"
+      description: Selecione os dias em que o evento irá ocorrer. (Múltipla escolha)
+      multiple: true
+      options:
+        - "01"
+        - "02"
+        - "03"
+        - "04"
+        - "05"
+        - "06"
+        - "07"
+        - "08"
+        - "09"
+        - "10"
+        - "11"
+        - "12"
+        - "13"
+        - "14"
+        - "15"
+        - "16"
+        - "17"
+        - "18"
+        - "19"
+        - "20"
+        - "21"
+        - "22"
+        - "23"
+        - "24"
+        - "25"
+        - "26"
+        - "27"
+        - "28"
+        - "29"
+        - "30"
+        - "31"
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Horário do Evento
+
+  - type: input
+    id: event_start_time
+    attributes:
+      label: "Horário de Início"
+      description: "Qual horário o evento irá começar?"
+      placeholder: "ex: 14:00"
+    validations:
+      required: true
+
+  - type: input
+    id: event_end_time
+    attributes:
+      label: "Horário de Término"
+      description: "Qual horário o evento irá terminar?"
+      placeholder: "ex: 18:00"
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Detalhes Adicionais
+
+  - type: textarea
+    id: event_description
+    attributes:
+      label: "Descrição do Evento"
+      description: "Conte mais sobre o evento."
+      placeholder: "ex: Este evento é sobre..."
+    validations:
+      required: true
+
+  - type: input
+    id: event_organizer
+    attributes:
+      label: "Nome do Organizador"
+      description: "Quem está organizando o evento?"
+      placeholder: "ex: João Silva"
+    validations:
+      required: true
+
+  - type: input
+    id: event_organizer_contact
+    attributes:
+      label: "Contato do Organizador"
+      description: "Como podemos entrar em contato com o organizador?"
+      placeholder: "ex: joao@email.com"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/adicionar_evento .yml
+++ b/.github/ISSUE_TEMPLATE/adicionar_evento .yml
@@ -1,6 +1,6 @@
 name: "Vamos adicionar um novo evento?😁"
 description: Utilize essa opção para adicionar um novo evento!
-title: "(Atenção: O Título da Issue é gerado automaticamente. Sendo assim, não precisa definir um título manualmente aqui.)"
+title: "adicionar evento"
 labels: ["adicionar"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/atualizar_evento.yml
+++ b/.github/ISSUE_TEMPLATE/atualizar_evento.yml
@@ -1,0 +1,182 @@
+name: "Atualizar informações de um evento 📅"
+description: Utilize essa opção para atualizar informações de um evento já cadastrado!
+title: "(Atenção: O Título da Issue é gerado automaticamente. Não precisa definir um título manualmente aqui.)"
+labels: ["atualizar"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Vamos atualizar um evento existente?
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Identifique o Evento a ser Atualizado
+
+  - type: input
+    id: event_name
+    attributes:
+      label: Nome do Evento
+      description: Qual o nome do evento que deseja atualizar?
+      placeholder: "ex: TDC 2025"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: event_format
+    attributes:
+      label: Formato do Evento
+      description: O evento será remoto, híbrido ou presencial?
+      multiple: false
+      options:
+        - Remoto
+        - Híbrido
+        - Presencial
+    validations:
+      required: true
+
+  - type: input
+    id: event_remote_url
+    attributes:
+      label: URL do Evento (caso remoto ou híbrido)
+      description: Informe a URL do evento se for remoto ou híbrido.
+      placeholder: "ex: https://evento-online.com/"
+    validations:
+      required: false
+ 
+  - type: markdown
+    attributes:
+      value: |
+        ## Atualize as Datas do Evento
+
+  - type: dropdown
+    id: event_year
+    attributes:
+      label: "Ano do Evento"
+      description: "Qual o ano do evento?"
+      multiple: false
+      default: 0
+      options:
+        - "2025"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: event_month
+    attributes:
+      label: "Mês do Evento"
+      description: Em qual mês irá acontecer o evento?
+      multiple: false
+      default: 0
+      options:
+        - A anunciar
+        - Janeiro
+        - Fevereiro
+        - Março
+        - Abril
+        - Maio
+        - Junho
+        - Julho
+        - Agosto
+        - Setembro
+        - Outubro
+        - Novembro
+        - Dezembro
+    validations:
+      required: true
+
+  - type: dropdown
+    id: event_day
+    attributes:
+      label: "Dia do Evento"
+      description: Selecione os dias em que o evento irá ocorrer. (Múltipla escolha)
+      multiple: true
+      options:
+        - "01"
+        - "02"
+        - "03"
+        - "04"
+        - "05"
+        - "06"
+        - "07"
+        - "08"
+        - "09"
+        - "10"
+        - "11"
+        - "12"
+        - "13"
+        - "14"
+        - "15"
+        - "16"
+        - "17"
+        - "18"
+        - "19"
+        - "20"
+        - "21"
+        - "22"
+        - "23"
+        - "24"
+        - "25"
+        - "26"
+        - "27"
+        - "28"
+        - "29"
+        - "30"
+        - "31"
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Atualize o Horário do Evento
+
+  - type: input
+    id: event_start_time
+    attributes:
+      label: "Horário de Início"
+      description: "Qual horário o evento irá começar?"
+      placeholder: "ex: 14:00"
+    validations:
+      required: true
+
+  - type: input
+    id: event_end_time
+    attributes:
+      label: "Horário de Término"
+      description: "Qual horário o evento irá terminar?"
+      placeholder: "ex: 18:00"
+    validations:
+      required: true
+
+  - type: markdown
+    attributes:
+      value: |
+        ## Atualize os Detalhes do Evento
+
+  - type: textarea
+    id: event_description
+    attributes:
+      label: "Descrição do Evento"
+      description: "Conte mais sobre o evento ou atualize as informações."
+      placeholder: "ex: Este evento é sobre..."
+    validations:
+      required: true
+
+  - type: input
+    id: event_organizer
+    attributes:
+      label: "Nome do Organizador"
+      description: "Quem está organizando o evento?"
+      placeholder: "ex: João Silva"
+    validations:
+      required: true
+
+  - type: input
+    id: event_organizer_contact
+    attributes:
+      label: "Contato do Organizador"
+      description: "Como podemos entrar em contato com o organizador?"
+      placeholder: "ex: joao@email.com"
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/atualizar_evento.yml
+++ b/.github/ISSUE_TEMPLATE/atualizar_evento.yml
@@ -1,6 +1,6 @@
 name: "Atualizar informações de um evento 📅"
 description: Utilize essa opção para atualizar informações de um evento já cadastrado!
-title: "(Atenção: O Título da Issue é gerado automaticamente. Não precisa definir um título manualmente aqui.)"
+title: "atualizar evento"
 labels: ["atualizar"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/remover_evento.yml
+++ b/.github/ISSUE_TEMPLATE/remover_evento.yml
@@ -1,6 +1,6 @@
 name: "Remover evento ❌"
 description: Utilize essa opção para solicitar a remoção de um evento já cadastrado.
-title: "(Atenção: O Título da Issue é gerado automaticamente. Não precisa definir um título manualmente aqui.)"
+title: "remover evento"
 labels: ["remover"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/remover_evento.yml
+++ b/.github/ISSUE_TEMPLATE/remover_evento.yml
@@ -1,0 +1,39 @@
+name: "Remover evento ❌"
+description: Utilize essa opção para solicitar a remoção de um evento já cadastrado.
+title: "(Atenção: O Título da Issue é gerado automaticamente. Não precisa definir um título manualmente aqui.)"
+labels: ["remover"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        # Solicitação de Remoção de Evento
+
+
+  - type: input
+    id: event_name
+    attributes:
+      label: Nome do Evento
+      description: Qual o nome do evento que deseja remover?
+      placeholder: "ex: TDC 2025"
+    validations:
+      required: true
+
+
+  - type: textarea
+    id: removal_reason
+    attributes:
+      label: Motivo da Remoção
+      description: Por que o evento deve ser removido?
+      placeholder: "ex: O evento foi cancelado, informações duplicadas, etc."
+    validations:
+      required: true
+
+
+  - type: input
+    id: requester_contact
+    attributes:
+      label: Seu contato
+      description: Como podemos entrar em contato com você para dúvidas sobre esta solicitação?
+      placeholder: "ex: seu@email.com"
+    validations:
+      required: true


### PR DESCRIPTION
Este PR modifica os templates de issues. Os nomes e labels foram padronizados para substantivo que indica o propósito do template. A mudança corrige o problema na atribuição automática dos labels. Todas as mudanças foram testadas em repositório de teste.
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/a8377614-bcfa-42af-915e-5cf8c3cec667" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/fdc99f3b-54c9-400b-b47f-74c5588adaa1" />
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/3e8d8448-48f3-435b-a3ce-f9206eaf21ee" />
fix #23 