### PR TITLE
Corrige workflow

### DIFF
--- a/.github/ISSUE_TEMPLATE/adicionar_evento.yml
+++ b/.github/ISSUE_TEMPLATE/adicionar_evento.yml
@@ -1,23 +1,23 @@
-name: "Atualizar informações de um evento 📅"
-description: Utilize essa opção para atualizar informações de um evento já cadastrado!
-title: "atualizar evento"
-labels: ["atualizar"]
+name: "Vamos adicionar um novo evento?😁"
+description: Utilize essa opção para adicionar um novo evento!
+title: "adicionar evento"
+labels: ["adicionar"]
 body:
   - type: markdown
     attributes:
       value: |
-        # Vamos atualizar um evento existente?
+        # Vamos criar um novo evento?
 
   - type: markdown
     attributes:
       value: |
-        ## Identifique o Evento a ser Atualizado
+        ## Informações Gerais do Evento
 
   - type: input
     id: event_name
     attributes:
       label: Nome do Evento
-      description: Qual o nome do evento que deseja atualizar?
+      description: Qual o nome do evento?
       placeholder: "ex: TDC 2025"
     validations:
       required: true
@@ -43,17 +43,17 @@ body:
       placeholder: "ex: https://evento-online.com/"
     validations:
       required: false
- 
+
   - type: markdown
     attributes:
       value: |
-        ## Atualize as Datas do Evento
+        ## Quando o evento vai acontecer?
 
   - type: dropdown
     id: event_year
     attributes:
       label: "Ano do Evento"
-      description: "Qual o ano do evento?"
+      description: "Qual o ano que irá acontecer o evento?"
       multiple: false
       default: 0
       options:
@@ -129,7 +129,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        ## Atualize o Horário do Evento
+        ## Horário do Evento
 
   - type: input
     id: event_start_time
@@ -152,13 +152,13 @@ body:
   - type: markdown
     attributes:
       value: |
-        ## Atualize os Detalhes do Evento
+        ## Detalhes Adicionais
 
   - type: textarea
     id: event_description
     attributes:
       label: "Descrição do Evento"
-      description: "Conte mais sobre o evento ou atualize as informações."
+      description: "Conte mais sobre o evento."
       placeholder: "ex: Este evento é sobre..."
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/remover_evento.yml
+++ b/.github/ISSUE_TEMPLATE/remover_evento.yml
@@ -1,7 +1,7 @@
 name: "Remover evento ❌"
 description: Utilize essa opção para solicitar a remoção de um evento já cadastrado.
-title: "(Atenção: O Título da Issue é gerado automaticamente. Não precisa definir um título manualmente aqui.)"
-labels: ["Remover", "template"]
+title: "remover evento"
+labels: ["remover"]
 body:
   - type: markdown
     attributes:

--- a/.github/workflows/exibir_dados_issue.yml
+++ b/.github/workflows/exibir_dados_issue.yml
@@ -1,26 +1,60 @@
-name: Exibir Dados da Issue
+name: Get Issue Data
 on:
   issues:
     types:
       - opened
       - edited
-jobs:
-  process_issue:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Imprimir Dados da Issue
-        run: |
-          echo "Titulo: ${{ github.event.issue.title }}"     
-          echo "Labels: ${{ toJson(github.event.issue.labels) }}"
-          echo "Numero: ${{ github.event.issue.number }}"  
-          echo "Corpo: ${{ github.event.issue.body }}"
 
-        steps:
-          - name: Checkout
-            uses: actions/checkout@v5
-          - name: Exibir dados da issue
-            run: |
-              echo "Descrição do evento: ${{ gh view issue ${{ github.event.issue.number }} body }}"
-            env:
-              GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-         
+jobs:
+  fetch_issue_data:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: true
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install GitHub CLI
+        run: sudo apt-get update && sudo apt-get install -y gh
+
+      - name: Authenticate GitHub CLI
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | gh auth login --with-token
+
+      - name: Create JSON with issue data
+        run: |
+          mkdir -p issues
+          FILE="issues/issue-${{ github.event.issue.number }}.json"
+          echo "FILE=$FILE" >> $GITHUB_ENV
+          gh issue view ${{ github.event.issue.number }} \
+            --repo ${{ github.repository }} \
+            --json number,title,body,labels,assignees,createdAt,updatedAt > "$FILE"
+
+      - name: Display issue data
+        run: cat "$FILE"
+      
+      
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Rodar o script de processamento
+        run: |
+          python script/processa_issue.py "$FILE"
+
+      - name: Commit to separate branch
+        run: |
+          BRANCH="issue-${{ github.event.issue.number }}"
+          git switch main || git switch -c main
+          git pull origin main
+          git switch -C "$BRANCH"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add "$FILE" script/processa_issue.py dados_extraidos.txt
+          git commit -m "Adding issue data #${{ github.event.issue.number }}" || echo "Nothing to commit"
+          git push origin "$BRANCH" --force

--- a/script/processa_issue.py
+++ b/script/processa_issue.py
@@ -1,0 +1,54 @@
+import re
+import json
+import sys
+
+def parse_issue(nome_arquivo : str) -> dict:
+    """
+    Recebe um JSON de issue do GitHub (dict) e retorna outro JSON (dict)
+    com os campos do body estruturados + label principal.
+    """
+    with open(nome_arquivo, "r", encoding="utf-8") as f:
+        issue = json.load(f)
+    # pega só o nome do primeiro label (se existir)
+    labels = [label["name"] for label in issue.get("labels", [])]
+    label = labels[0] if labels else ""
+
+    resultado = {
+        
+        "title": issue.get("title", ""),
+        "label": label,
+        "labels": labels,
+    }
+
+    body = issue.get("body", "")
+
+    # Extrair blocos do tipo ### Campo \n valor
+    padrao_markdown = re.compile(r"###\s*(.*?)\n+([^#]+)", re.DOTALL)
+    for campo, valor in padrao_markdown.findall(body):
+        chave = campo.strip().lower().replace(" ", "_")
+        resultado[chave] = valor.strip()
+
+    # Extrair blocos do tipo **Campo**: valor
+    padrao_negrito = re.compile(r"\*\*(.*?)\*\*:\s*(.*)")
+    for campo, valor in padrao_negrito.findall(body):
+        chave = campo.strip().lower().replace(" ", "_")
+        resultado[chave] = valor.strip()
+    
+    print(resultado)
+    with open(nome_arquivo, "w", encoding="utf-8") as f:
+        json.dump(resultado, f, indent=2, ensure_ascii=False)
+    
+    labels_permitidos = ['adicionar', 'remover', 'atualizar']
+    # exibir dados extraídos
+    with  open('dados_extraidos.txt', 'w', encoding='utf-8') as f:
+        for chave, valor in resultado.items():
+            if chave == 'label' and valor in labels_permitidos:
+                f.write(f"{chave}: {valor}\n")
+            if chave == 'nome do evento':
+                f.write(f"{chave}: {valor}\n")
+
+# Exemplo de uso
+if __name__ == "__main__":
+    arquivo = sys.argv[1] 
+    print("ok")
+    parse_issue(arquivo)


### PR DESCRIPTION
Este PR adapta o workflow para imprimir informações sobre issue. Para isso, foi criado um parse que recebe um JSON contendo Markdown, onde o corpo da issue fica em uma única chave `body` como mostrado a seguir:
`{ "number": "7", "title": "adicionar evento", "body": "### Nome do Evento teste 333333333 ### Formato do Evento Remoto ### URL do Evento (caso remoto ou híbrido) https://github.com/Joaolpridolficarvalho/teste/issues ### Ano do Evento 2025 ### Mês do Evento Agosto ### Dia do Evento 29 ### Horário de Início 15:00 ### Horário de Término 18:00 ### Descrição do Evento ggg nn ### Nome do Organizador jl ### Contato do Organizador jlprcarvalho@gmail.com", "labels": [ { "color": "e6b683", "default": false, "description": "", "id": 9130974802, "name": "adicionar", "node_id": "LA_kwDOPdRzEc8AAAACID-eUg", "url": "https://api.github.com/repos/Joaolpridolficarvalho/teste/labels/adicionar" } ], "user": "Joaolpridolficarvalho" }` e retorna um JSON limpo, onde as chaves correspondem aos campos da issue, sejam eles quais forem, segue um exemplo:
`{
  "title": "adicionar evento",
  "label": "adicionar",
  "labels": [
    "adicionar"
  ],
  "nome_do_evento": "Python Brasil 2025",
  "formato_do_evento": "Presencial",
  "url_do_evento_(caso_remoto_ou_híbrido)": "https://pythonbrasil.org.br",
  "ano_do_evento": "2025",
  "mês_do_evento": "Outubro",
  "dia_do_evento": "18",
  "horário_de_início": "08:30",
  "horário_de_término": "18:30",
  "descrição_do_evento": "Maior conferência Python do Brasil, reunindo desenvolvedores, cientistas de dados e entusiastas da linguagem. O evento contará com palestras, workshops, sprints e networking sobre desenvolvimento web, ciência de dados, machine learning e muito mais.",
  "nome_do_organizador": "Associação Python Brasil",
  "contato_do_organizador": "contato@pythonbrasil.org.br"
}`
Também foi gerado um arquivo .txt contendo o nome do evento e o label.
Closes #24 