### PR TITLE
Adiona workflow adiciona_evento 

### DIFF
--- a/.github/workflows/adicionar_evento.yml
+++ b/.github/workflows/adicionar_evento.yml
@@ -1,0 +1,14 @@
+name: Exibir informações da Issue
+
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  mostrar-info:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Exibir número e labels da issue
+        run: |
+          echo "Número da issue: ${{ github.event.issue.number }}"
+          echo "Labels: ${{ toJson(github.event.issue.labels) }}"


### PR DESCRIPTION
## Descrição
Cria workflow para exibir o número e labels de issue quando ela é aberta ou editada.

## Mudanças Propostas
- Adiciona o arquivo `.github/workflows/adicionar_evento.yml`.
## Benefícios da Mudança
Permite monitorar o número e os labels das issues abertas ou editadas, facilitando a gestão e organização do projeto.

## Como Testar
Crie ou edite uma issue no repositório e verifique os logs do workflow para confirmar que o número e os labels da issue foram exibidos corretamente.

## Anexos
<img width="1788" height="907" alt="image" src="https://github.com/user-attachments/assets/9e6d3143-d80e-40df-843c-f29cbc8f1ef6" />


## Checklist de Revisão
<!--- Marque as caixas que se aplicam. Você pode deixar caixas desmarcadas se elas não se aplicarem.-->
- [x] Eu testei minhas mudanças localmente e/ou em um repositório de teste.
- [x] Eu certiifiquei que meu código segue as diretrizes de estilo do projeto.
- [x] Eu certiifiquei que a branch contém apenas mudanças relacionadas a este Pull Request.


## Issue Relacionada
<!---Todos os PRs devem ter uma issue relacionada. Dessa forma, podemos garantir que ninguém perca tempo trabalhando em algo que não precisa ser feito. -->

Closes #41
