### PR TITLE
Atualiza workflow e adiciona pasta backend

### DIFF
--- a/.github/workflows/adicionar_evento.yml
+++ b/.github/workflows/adicionar_evento.yml
@@ -7,20 +7,34 @@ on:
 jobs:
   mostrar-info:
     runs-on: ubuntu-latest
+    env:
+      NOME_ARQUIVO: issue_data.json
     steps:
+      - name: Verificar checkout do repositório
+        uses: actions/checkout@v4
+
       - name: Exibir número e labels da issue
         run: |
           echo "Número da issue: ${{ github.event.issue.number }}"
           echo "Labels: ${{ toJson(github.event.issue.labels) }}"
-      
+
+      - name: Converter issue para JSON
+        uses: zentered/issue-forms-body-parser@v2.0.0
+        id: parse
+
+      - name: Salvar dados da issue em um arquivo
+        run: |
+          echo '${{ steps.parse.outputs.data }}' > $NOME_ARQUIVO
+        
+  
       - name: Verificar se a issue tem a label 'evento:adicionar'
         if: contains(join(github.event.issue.labels.*.name, ','), '🗓️ evento:adicionar')
         run: |
           echo "A issue contém a label 'evento:adicionar'."
-          # Adicione aqui o código para processar a issue conforme necessário
+          python3 backend/adicionar_evento.py ${NOME_ARQUIVO}
+         
 
       - name: Verificar se a issue NÃO tem a label 'evento:adicionar'
         if: ${{ !contains(join(github.event.issue.labels.*.name, ','), '🗓️ evento:adicionar') }}
         run: |
           echo "A issue não contém a label 'evento:adicionar'."
-          #  Abstrair isso para arquivo .py

--- a/backend/adicionar_evento.py
+++ b/backend/adicionar_evento.py
@@ -1,0 +1,14 @@
+import json
+
+def carregar_dados_issues():
+    
+    with open('issue_data.json', 'r') as file:
+        return json.load(file)
+    
+def imprimir_issue(issue):
+    print(issue)
+
+if __name__ == "__main__":
+    labels = ['🗓️ evento:adicionar']
+    dados_issues = carregar_dados_issues()
+    imprimir_issue(dados_issues)


### PR DESCRIPTION
## Descrição
Modifica o workflow para executar o script `adicionar_evento.py` imprimindo o JSON da issue quando uma issue é criada ou editada com o label "🗓️ evento:adicionar" e limpar a saída. 

## Mudanças Propostas
- Atualiza o arquivo `.github/workflows/adicionar_evento.yml`.
- Adiciona o script `backend/adicionar_evento.py` que extrai e imprime o JSON da issue.
## Benefícios da Mudança
Permite melhor organização do código e facilita a manutenção do workflow.

## Como Testar
Crie ou edite uma issue com o label "🗓️ evento:adicionar" e uma issue sem esse label. Verifique se o workflow exibe o json corretamente.

## Anexos
https://github.com/[Joaolpridolficarvalho/teste](https://github.com/Joaolpridolficarvalho/teste)


## Checklist de Revisão
<!--- Marque as caixas que se aplicam. Você pode deixar caixas desmarcadas se elas não se aplicarem.-->
- [x] Eu testei minhas mudanças localmente e/ou em um repositório de teste.
- [x] Eu certiifiquei que meu código segue as diretrizes de estilo do projeto.
- [x] Eu certiifiquei que a branch contém apenas mudanças relacionadas a este Pull Request.


## Issue Relacionada
<!---Todos os PRs devem ter uma issue relacionada. Dessa forma, podemos garantir que ninguém perca tempo trabalhando em algo que não precisa ser feito. -->

Closes #46
