### PR TITLE
Adiciona regras de negócio e testes ao validar_evento

### DIFF
--- a/backend/validar_evento.py
+++ b/backend/validar_evento.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+from datetime import date
 
 from jsonschema import validate
 
@@ -13,14 +14,87 @@ caminho_esquema = os.path.join(BASE_DIR, "esquema_issue_evento.json")
 with open(caminho_esquema, encoding="utf-8") as f:
     esquema_issue_evento = json.load(f)
 
+MESES = {
+    "Janeiro": 1,
+    "Fevereiro": 2,
+    "Março": 3,
+    "Abril": 4,
+    "Maio": 5,
+    "Junho": 6,
+    "Julho": 7,
+    "Agosto": 8,
+    "Setembro": 9,
+    "Outubro": 10,
+    "Novembro": 11,
+    "Dezembro": 12,
+}
 
-def validar_evento(evento):
+
+def validar_esquema(evento):
     try:
         validate(instance=evento, schema=esquema_issue_evento)
         return True
     except Exception as e:
-        print(f"Erro ao validar evento: {e}")
+        print(f"Erro ao validar esquema: {e}")
         return False
+
+
+def extrair_data(evento, prefixo):
+    ano = int(evento[f"ano-do-{prefixo}"]["text"])
+    mes = MESES[evento[f"mes-do-{prefixo}"]["text"]]
+    dia = int(evento[f"dia-do-{prefixo}"]["text"])
+    return date(ano, mes, dia)
+
+
+def validar_datas(evento):
+    try:
+        primeiro_dia_evento = extrair_data(evento, "primeiro-dia-de-evento")
+        ultimo_dia_evento = extrair_data(evento, "ultimo-dia-de-evento")
+        primeiro_dia_submissao = extrair_data(evento, "primeiro-dia-de-submissao")
+        ultimo_dia_submissao = extrair_data(evento, "ultimo-dia-de-submissao")
+    except ValueError as e:
+        print(f"Data inválida no calendário: {e}")
+        return False
+
+    if ultimo_dia_evento < primeiro_dia_evento:
+        print("Último dia do evento é anterior ao primeiro dia.")
+        return False
+
+    if ultimo_dia_submissao < primeiro_dia_submissao:
+        print("Último dia de submissão é anterior ao primeiro dia.")
+        return False
+
+    if ultimo_dia_submissao > primeiro_dia_evento:
+        print("Submissão termina depois do evento começar.")
+        return False
+
+    return True
+
+
+def validar_duplicidade(evento, caminho_eventos=None):
+    if caminho_eventos is None:
+        caminho_eventos = os.path.join(BASE_DIR, "banco_de_dados", "eventos.json")
+
+    with open(caminho_eventos, encoding="utf-8") as f:
+        eventos_existentes = json.load(f)
+
+    nome = evento["nome-do-evento"]["text"]
+    for e in eventos_existentes:
+        if e["nome"] == nome:
+            print(f"Evento '{nome}' já existe no banco de dados.")
+            return False
+
+    return True
+
+
+def validar_evento(evento, caminho_eventos=None):
+    if not validar_esquema(evento):
+        return False
+    if not validar_datas(evento):
+        return False
+    if not validar_duplicidade(evento, caminho_eventos):
+        return False
+    return True
 
 
 def carregar_evento_de_arquivo(caminho_arquivo):

--- a/tests/test_validar_evento.py
+++ b/tests/test_validar_evento.py
@@ -1,0 +1,290 @@
+import copy
+import json
+import os
+import tempfile
+
+import pytest
+
+from backend.validar_evento import (
+    validar_datas,
+    validar_duplicidade,
+    validar_esquema,
+    validar_evento,
+)
+
+
+def _campo(texto, titulo="Titulo"):
+    """Cria um campo no formato do issue-forms-body-parser."""
+    return {"title": titulo, "content": [texto], "text": texto}
+
+
+@pytest.fixture
+def evento_valido():
+    return {
+        "nome-do-evento": _campo("Python Brasil 2026"),
+        "site-do-evento": _campo("https://pythonbrasil.org.br"),
+        "formato-do-evento": _campo("Presencial"),
+        "cidade-deixe-em-branco-se-online": _campo("Brasília"),
+        "estado-provincia-deixe-em-branco-se-online": _campo("DF"),
+        "pais-deixe-em-branco-se-online": _campo("BR"),
+        "ano-do-primeiro-dia-de-evento": _campo("2026"),
+        "mes-do-primeiro-dia-de-evento": _campo("Outubro"),
+        "dia-do-primeiro-dia-de-evento": _campo("20"),
+        "ano-do-ultimo-dia-de-evento": _campo("2026"),
+        "mes-do-ultimo-dia-de-evento": _campo("Outubro"),
+        "dia-do-ultimo-dia-de-evento": _campo("25"),
+        "ano-do-primeiro-dia-de-submissao": _campo("2026"),
+        "mes-do-primeiro-dia-de-submissao": _campo("Janeiro"),
+        "dia-do-primeiro-dia-de-submissao": _campo("01"),
+        "ano-do-ultimo-dia-de-submissao": _campo("2026"),
+        "mes-do-ultimo-dia-de-submissao": _campo("Junho"),
+        "dia-do-ultimo-dia-de-submissao": _campo("30"),
+        "tipos-de-submissao-aceitos": {
+            "title": "Tipos de Submissão aceitos",
+            "content": ["Palestra", "Workshop"],
+            "text": "",
+            "list": [
+                {"checked": True, "text": "Palestra"},
+                {"checked": True, "text": "Workshop"},
+                {"checked": False, "text": "Lightning talk"},
+                {"checked": False, "text": "Painel"},
+                {"checked": False, "text": "Tutorial"},
+                {"checked": False, "text": "Minicurso"},
+                {"checked": False, "text": "Outros (especificar abaixo)"},
+            ],
+        },
+        "se-marcou-outros-especifique": _campo(""),
+    }
+
+
+# =====================================================================
+# Validação de esquema (JSON Schema)
+# =====================================================================
+
+
+class TestValidarEsquema:
+    def test_evento_valido(self, evento_valido):
+        assert validar_esquema(evento_valido) is True
+
+    def test_evento_online_sem_local(self, evento_valido):
+        evento = copy.deepcopy(evento_valido)
+        evento["formato-do-evento"] = _campo("Online")
+        del evento["cidade-deixe-em-branco-se-online"]
+        del evento["estado-provincia-deixe-em-branco-se-online"]
+        del evento["pais-deixe-em-branco-se-online"]
+        assert validar_esquema(evento) is True
+
+    def test_evento_hibrido(self, evento_valido):
+        evento = copy.deepcopy(evento_valido)
+        evento["formato-do-evento"] = _campo("Híbrido")
+        assert validar_esquema(evento) is True
+
+    @pytest.mark.parametrize(
+        "campo",
+        [
+            "nome-do-evento",
+            "site-do-evento",
+            "formato-do-evento",
+            "ano-do-primeiro-dia-de-evento",
+            "mes-do-primeiro-dia-de-evento",
+            "dia-do-primeiro-dia-de-evento",
+            "ano-do-ultimo-dia-de-evento",
+            "mes-do-ultimo-dia-de-evento",
+            "dia-do-ultimo-dia-de-evento",
+            "ano-do-primeiro-dia-de-submissao",
+            "mes-do-primeiro-dia-de-submissao",
+            "dia-do-primeiro-dia-de-submissao",
+            "ano-do-ultimo-dia-de-submissao",
+            "mes-do-ultimo-dia-de-submissao",
+            "dia-do-ultimo-dia-de-submissao",
+            "tipos-de-submissao-aceitos",
+            "se-marcou-outros-especifique",
+        ],
+    )
+    def test_campo_obrigatorio_ausente(self, evento_valido, campo):
+        evento = copy.deepcopy(evento_valido)
+        del evento[campo]
+        assert validar_esquema(evento) is False
+
+    def test_formato_evento_invalido(self, evento_valido):
+        evento = copy.deepcopy(evento_valido)
+        evento["formato-do-evento"] = _campo("Virtual")
+        assert validar_esquema(evento) is False
+
+    def test_dia_invalido_maior_que_31(self, evento_valido):
+        evento = copy.deepcopy(evento_valido)
+        evento["dia-do-primeiro-dia-de-evento"] = _campo("32")
+        assert validar_esquema(evento) is False
+
+    def test_dia_invalido_zero(self, evento_valido):
+        evento = copy.deepcopy(evento_valido)
+        evento["dia-do-primeiro-dia-de-evento"] = _campo("00")
+        assert validar_esquema(evento) is False
+
+    def test_dia_invalido_texto(self, evento_valido):
+        evento = copy.deepcopy(evento_valido)
+        evento["dia-do-primeiro-dia-de-evento"] = _campo("abc")
+        assert validar_esquema(evento) is False
+
+    def test_mes_invalido(self, evento_valido):
+        evento = copy.deepcopy(evento_valido)
+        evento["mes-do-primeiro-dia-de-evento"] = _campo("Janero")
+        assert validar_esquema(evento) is False
+
+    def test_ano_invalido_curto(self, evento_valido):
+        evento = copy.deepcopy(evento_valido)
+        evento["ano-do-primeiro-dia-de-evento"] = _campo("26")
+        assert validar_esquema(evento) is False
+
+    def test_campo_sem_text(self, evento_valido):
+        evento = copy.deepcopy(evento_valido)
+        evento["nome-do-evento"] = {"title": "Nome", "content": ["teste"]}
+        assert validar_esquema(evento) is False
+
+    def test_campo_sem_title(self, evento_valido):
+        evento = copy.deepcopy(evento_valido)
+        evento["nome-do-evento"] = {"content": ["teste"], "text": "teste"}
+        assert validar_esquema(evento) is False
+
+    def test_evento_vazio(self):
+        assert validar_esquema({}) is False
+
+
+# =====================================================================
+# Validação de datas (regras de negócio)
+# =====================================================================
+
+
+class TestValidarDatas:
+    def test_datas_validas(self, evento_valido):
+        assert validar_datas(evento_valido) is True
+
+    def test_evento_um_dia(self, evento_valido):
+        evento = copy.deepcopy(evento_valido)
+        evento["ano-do-ultimo-dia-de-evento"] = _campo("2026")
+        evento["mes-do-ultimo-dia-de-evento"] = _campo("Outubro")
+        evento["dia-do-ultimo-dia-de-evento"] = _campo("20")
+        assert validar_datas(evento) is True
+
+    def test_31_de_fevereiro(self, evento_valido):
+        evento = copy.deepcopy(evento_valido)
+        evento["mes-do-primeiro-dia-de-evento"] = _campo("Fevereiro")
+        evento["dia-do-primeiro-dia-de-evento"] = _campo("31")
+        assert validar_datas(evento) is False
+
+    def test_30_de_fevereiro(self, evento_valido):
+        evento = copy.deepcopy(evento_valido)
+        evento["mes-do-primeiro-dia-de-evento"] = _campo("Fevereiro")
+        evento["dia-do-primeiro-dia-de-evento"] = _campo("30")
+        assert validar_datas(evento) is False
+
+    def test_29_fevereiro_ano_nao_bissexto(self, evento_valido):
+        evento = copy.deepcopy(evento_valido)
+        evento["ano-do-primeiro-dia-de-evento"] = _campo("2027")
+        evento["mes-do-primeiro-dia-de-evento"] = _campo("Fevereiro")
+        evento["dia-do-primeiro-dia-de-evento"] = _campo("29")
+        evento["ano-do-ultimo-dia-de-evento"] = _campo("2027")
+        evento["mes-do-ultimo-dia-de-evento"] = _campo("Março")
+        evento["dia-do-ultimo-dia-de-evento"] = _campo("01")
+        assert validar_datas(evento) is False
+
+    def test_29_fevereiro_ano_bissexto(self, evento_valido):
+        evento = copy.deepcopy(evento_valido)
+        evento["ano-do-primeiro-dia-de-evento"] = _campo("2028")
+        evento["mes-do-primeiro-dia-de-evento"] = _campo("Fevereiro")
+        evento["dia-do-primeiro-dia-de-evento"] = _campo("29")
+        evento["ano-do-ultimo-dia-de-evento"] = _campo("2028")
+        evento["mes-do-ultimo-dia-de-evento"] = _campo("Março")
+        evento["dia-do-ultimo-dia-de-evento"] = _campo("01")
+        assert validar_datas(evento) is True
+
+    def test_31_de_abril(self, evento_valido):
+        evento = copy.deepcopy(evento_valido)
+        evento["mes-do-primeiro-dia-de-evento"] = _campo("Abril")
+        evento["dia-do-primeiro-dia-de-evento"] = _campo("31")
+        assert validar_datas(evento) is False
+
+    def test_ultimo_dia_evento_antes_do_primeiro(self, evento_valido):
+        evento = copy.deepcopy(evento_valido)
+        evento["dia-do-primeiro-dia-de-evento"] = _campo("25")
+        evento["dia-do-ultimo-dia-de-evento"] = _campo("20")
+        assert validar_datas(evento) is False
+
+    def test_ultimo_dia_submissao_antes_do_primeiro(self, evento_valido):
+        evento = copy.deepcopy(evento_valido)
+        evento["mes-do-primeiro-dia-de-submissao"] = _campo("Junho")
+        evento["dia-do-primeiro-dia-de-submissao"] = _campo("30")
+        evento["mes-do-ultimo-dia-de-submissao"] = _campo("Janeiro")
+        evento["dia-do-ultimo-dia-de-submissao"] = _campo("01")
+        assert validar_datas(evento) is False
+
+    def test_submissao_termina_depois_do_evento_comecar(self, evento_valido):
+        evento = copy.deepcopy(evento_valido)
+        evento["mes-do-ultimo-dia-de-submissao"] = _campo("Novembro")
+        evento["dia-do-ultimo-dia-de-submissao"] = _campo("01")
+        assert validar_datas(evento) is False
+
+    def test_submissao_termina_no_dia_do_evento(self, evento_valido):
+        evento = copy.deepcopy(evento_valido)
+        evento["mes-do-ultimo-dia-de-submissao"] = _campo("Outubro")
+        evento["dia-do-ultimo-dia-de-submissao"] = _campo("20")
+        assert validar_datas(evento) is True
+
+
+# =====================================================================
+# Validação de duplicidade
+# =====================================================================
+
+
+class TestValidarDuplicidade:
+    def _criar_arquivo_eventos(self, eventos):
+        arquivo = tempfile.NamedTemporaryFile(
+            mode="w", suffix=".json", delete=False, encoding="utf-8"
+        )
+        json.dump(eventos, arquivo)
+        arquivo.close()
+        return arquivo.name
+
+    def test_evento_novo_sem_duplicidade(self, evento_valido):
+        caminho = self._criar_arquivo_eventos([])
+        try:
+            assert validar_duplicidade(evento_valido, caminho) is True
+        finally:
+            os.unlink(caminho)
+
+    def test_evento_duplicado(self, evento_valido):
+        eventos_existentes = [{"nome": "Python Brasil 2026"}]
+        caminho = self._criar_arquivo_eventos(eventos_existentes)
+        try:
+            assert validar_duplicidade(evento_valido, caminho) is False
+        finally:
+            os.unlink(caminho)
+
+    def test_evento_nome_diferente(self, evento_valido):
+        eventos_existentes = [{"nome": "Python Nordeste 2026"}]
+        caminho = self._criar_arquivo_eventos(eventos_existentes)
+        try:
+            assert validar_duplicidade(evento_valido, caminho) is True
+        finally:
+            os.unlink(caminho)
+
+
+# =====================================================================
+# Validação completa (integração)
+# =====================================================================
+
+
+class TestValidarEvento:
+    def test_evento_valido_completo(self, evento_valido):
+        assert validar_evento(evento_valido) is True
+
+    def test_esquema_invalido_rejeita(self, evento_valido):
+        evento = copy.deepcopy(evento_valido)
+        del evento["nome-do-evento"]
+        assert validar_evento(evento) is False
+
+    def test_data_invalida_rejeita(self, evento_valido):
+        evento = copy.deepcopy(evento_valido)
+        evento["mes-do-primeiro-dia-de-evento"] = _campo("Fevereiro")
+        evento["dia-do-primeiro-dia-de-evento"] = _campo("31")
+        assert validar_evento(evento) is False


### PR DESCRIPTION
## O que foi feito

- O arquivo `validar_evento.py` foi refatorado para separar a validação em etapas: esquema, datas e duplicidade.
- Foram adicionadas validações de regras de negócio: datas reais no calendário (ex: rejeita 31 de fevereiro, 29/fev em ano não-bissexto), ordem das datas (último dia >= primeiro dia, submissão encerra antes do evento) e duplicidade simples por nome.
- O arquivo `test_validar_evento.py` foi criado com 46 testes organizados em 4 classes: esquema, datas, duplicidade e integração.

## Por que

Essas mudanças completam o item 5.7 do roadmap, garantindo que eventos com datas impossíveis, ordem invertida ou nomes duplicados sejam rejeitados.

## Como testar

```bash
make test
make lint
```

Os 48 testes cobrem:
- Casos válidos (evento completo, online, híbrido, evento de 1 dia, ano bissexto)
- Campos obrigatórios ausentes (17 parametrizados)
- Valores inválidos (formato, dia, mês, ano)
- Datas impossíveis (31/fev, 30/fev, 31/abr, 29/fev em ano não-bissexto)
- Ordem incorreta (último dia antes do primeiro, submissão após evento)
- Duplicidade (evento já existente no banco de dados)

## Checklist

- [x] Lint passando (`make lint`)
- [x] Testes passando (`make test`)
- [x] Testes adicionados para funcionalidades novas (se aplicável)

closes #53