### PR TITLE
Habilita adiciona evento

### DIFF
--- a/.github/workflows/adicionar_evento.yml
+++ b/.github/workflows/adicionar_evento.yml
@@ -3,6 +3,8 @@ name: Exibir informações da Issue
 on:
   issues:
     types: [opened, edited]
+    labels:
+      - '🗓️ evento:adicionar'
 
 jobs:
   mostrar-info:
@@ -29,6 +31,6 @@ jobs:
         run: |
           python3 backend/validar_evento.py ${{github.workspace}}/$NOME_ARQUIVO
 
-      # - name: Executar script de adicionar evento
-      #   run: |
-      #     python3 backend/adicionar_evento.py
+      - name: Executar script de adicionar evento
+        run: |
+          python3 backend/adicionar_evento.py ${{github.workspace}}/$NOME_ARQUIVO

--- a/.github/workflows/adicionar_evento.yml
+++ b/.github/workflows/adicionar_evento.yml
@@ -3,8 +3,7 @@ name: Exibir informações da Issue
 on:
   issues:
     types: [opened, edited]
-    labels:
-      - '🗓️ evento:adicionar'
+    
 
 jobs:
   mostrar-info:


### PR DESCRIPTION
## O que foi feito

- A step para adicionar evento foi habilitada.

## Por que

A step para adicionar evento estava desabilitada, o que impedia a criação de eventos no banco de dados. Habilitar essa step é essencial para seguir com o desenvolvimento e testes relacionados à funcionalidade de adicionar eventos.

## Como testar

Crie uma issue com um evento válido e verifique se ele é adicionado corretamente ao banco de dados. 

## Checklist

- [x] Lint passando (`make lint`)
- [x] Testes passando (`make test`)
- [x] Testes adicionados para funcionalidades novas (se aplicável)
fix #66 
