### PR TITLE
Corrige ModuleNotFoundError no workflow de adicionar evento

### DIFF
--- a/.github/workflows/adicionar_evento.yml
+++ b/.github/workflows/adicionar_evento.yml
@@ -28,8 +28,8 @@ jobs:
 
       - name: Executar script para validar evento
         run: |
-          python3 backend/validar_evento.py ${{github.workspace}}/$NOME_ARQUIVO
+          python3 -m backend.validar_evento ${{github.workspace}}/$NOME_ARQUIVO
 
       - name: Executar script de adicionar evento
         run: |
-          python3 backend/adicionar_evento.py ${{github.workspace}}/$NOME_ARQUIVO
+          python3 -m backend.adicionar_evento ${{github.workspace}}/$NOME_ARQUIVO


### PR DESCRIPTION
## O que foi feito

- Os steps que executam os scripts Python no workflow `adicionar_evento.yml` agora usam `python3 -m backend.<script>` no lugar de `python3 backend/<script>.py`.

## Por que

O `adicionar_evento.py` importa de `backend.validar_evento`. Quando executado direto com `python3 backend/adicionar_evento.py`, o Python adiciona a pasta `backend/` ao `sys.path` em vez da raiz do repo, causando `ModuleNotFoundError: No module named 'backend'`. Isso estava quebrando a adição de eventos reais no workflow ([exemplo da falha](https://github.com/cumbucadev/agenda-palestrinha/actions/runs/24799650929/job/72578556394)).

Rodar com `python3 -m` adiciona a pasta corrente (raiz do repo) ao `sys.path` e resolve o import. A mesma mudança foi aplicada ao `validar_evento.py` por consistência.

## Como testar

Abra uma issue usando o template de adicionar evento e verifique no log do GitHub Actions se os dois steps (`validar evento` e `adicionar evento`) passam sem erro e o evento é persistido no `eventos.json`.

Para testar localmente:

```bash
python3 -m backend.adicionar_evento caminho/para/issue_data.json
```

## Checklist

- [x] Lint passando (`make lint`)
- [x] Testes passando (`make test`)
- [ ] Testes adicionados para funcionalidades novas (se aplicável)